### PR TITLE
don't feed non valid laser data to stereo tracker and skip

### DIFF
--- a/src/Trackers/OpenVSLAMStereoTracker.cpp
+++ b/src/Trackers/OpenVSLAMStereoTracker.cpp
@@ -284,6 +284,10 @@ TrackerBase::ProcessImageResult OpenVSLAMStereoTracker::processImage(CameraQueue
             }
         }
 
+    } else {
+        // Don't continue if there is no valid laser data
+        spdlog::error("Laser data is not valid or empty");
+        return res;
     }
 
     {


### PR DESCRIPTION
I noticed this problem when running `lpslam_node` requesting the laser data to be `SystemDefaultsQoS` (reliable) and having the laser data published in `SensorDataQoS` (best effort). 
QoS incompatibility resulted in having an empty laser data which caused a crash in `lpslam_node`. When the laser data is empty or not valid, it shouldn't be fed to the tracker and no map can be created in this case.