### PR TITLE
Fix g2o/lopengl_helper build failure

### DIFF
--- a/conan-packages/g2o-conan/conanfile.py
+++ b/conan-packages/g2o-conan/conanfile.py
@@ -87,7 +87,7 @@ class G2oConan(ConanFile):
         # to export the symbols of csparse
         cmake.definitions["G2O_LGPL_SHARED_LIBS"] = True
 
-        cmake.definitions["G2O_USE_OPENGL"] = False
+        cmake.definitions["G2O_USE_OPENGL"] = True
         # disabled threading because its experimental
         # and spams processing with many threads on Windows
         cmake.definitions["G2O_USE_OPENMP"] = False


### PR DESCRIPTION
Building g2o fails with the following error: `/usr/bin/ld: cannot find -lopengl_helper`. 
This is related to this [g2o issue](https://github.com/RainerKuemmerle/g2o/issues/362) and can be fixed by setting  `-DG2O_USE_OPENGL=ON` as mentioned in the issue discussion.